### PR TITLE
Fix alias unrolling in anonymous namespace with GDB

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -205,7 +205,8 @@ export class Debugger {
     async unrollTypeAlias(type: string): Promise<string> {
         const debuggerName = this.sessionInfo?.debugger;
         if (debuggerName === 'gdb') {
-            const evalResult = (await this.evaluate("-exec ptype /rmt '" + type + "'"))?.result;
+            const typeEscaped = type.replace('(anonymous namespace)', "'(anonymous namespace)'");
+            const evalResult = (await this.evaluate('-exec ptype /rmt ' + typeEscaped))?.result;
             let typeInfo: string = typeof evalResult === 'string' ? evalResult.trim() : '';
             if (typeInfo.startsWith('type = ')) {
                 // console.log(typeInfo);

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -205,7 +205,7 @@ export class Debugger {
     async unrollTypeAlias(type: string): Promise<string> {
         const debuggerName = this.sessionInfo?.debugger;
         if (debuggerName === 'gdb') {
-            const evalResult = (await this.evaluate('-exec ptype /rmt ' + type))?.result;
+            const evalResult = (await this.evaluate("-exec ptype /rmt '" + type + "'"))?.result;
             let typeInfo: string = typeof evalResult === 'string' ? evalResult.trim() : '';
             if (typeInfo.startsWith('type = ')) {
                 // console.log(typeInfo);

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -205,7 +205,7 @@ export class Debugger {
     async unrollTypeAlias(type: string): Promise<string> {
         const debuggerName = this.sessionInfo?.debugger;
         if (debuggerName === 'gdb') {
-            const typeEscaped = type.replace('(anonymous namespace)', "'(anonymous namespace)'");
+            const typeEscaped = type.replace('(anonymous namespace)::', "'(anonymous namespace)'::");
             const evalResult = (await this.evaluate('-exec ptype /rmt ' + typeEscaped))?.result;
             let typeInfo: string = typeof evalResult === 'string' ? evalResult.trim() : '';
             if (typeInfo.startsWith('type = ')) {


### PR DESCRIPTION
For a type alias defined inside an anonymous namespace, GDB returns ``A syntax error in expression, near `(anonymous namespace)::[...]`.``. Enclosing the name of the type with single quotes seems to fix this.